### PR TITLE
Add dates to audio files

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -65,6 +65,18 @@ module.exports = (eleventyConfig) => {
     return new Date(dateValue).toUTCString();
   });
 
+  eleventyConfig.addLiquidFilter('pageDate', (dateValue) => {
+    const date = new Date(dateValue);
+
+    const options = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    };
+
+    return date.toLocaleDateString('en-GB', options);
+  });
+
   eleventyConfig.addLiquidFilter('xmlEscape', (value) => {
     return escape(value);
   });

--- a/src/_includes/default.html
+++ b/src/_includes/default.html
@@ -14,7 +14,10 @@
     {% endif %}
 
     <main class="w-80 center bg-white mv2 pv2 ph1 ph3-ns">
-      <h2 class="f3 f2-ns mt3 mb1">{{title}}</h2>
+      <h2 class="f3 f2-ns mt3 mb1 near-black">{{title}}</h2>
+      {% if showDate %}
+      <h3 class="f5 f4-ns mt2 mb1 gray">{{page.date | pageDate}}</h3>
+      {% endif %}
       <div class="h2 w2 bb bw2 b--near-black"></div>
       <div class="pt4">
         {{content}}

--- a/src/pages/mixes/mixes.11tydata.json
+++ b/src/pages/mixes/mixes.11tydata.json
@@ -1,0 +1,3 @@
+{
+  "showDate": true
+}

--- a/src/pages/podcasts/podcasts.11tydata.json
+++ b/src/pages/podcasts/podcasts.11tydata.json
@@ -1,0 +1,3 @@
+{
+  "showDate": true
+}

--- a/src/pages/productions/productions.11tydata.json
+++ b/src/pages/productions/productions.11tydata.json
@@ -1,0 +1,3 @@
+{
+  "showDate": true
+}


### PR DESCRIPTION
## Changes

- Add `pageDate` filter
- Show date on default page if `showDate` is `true`
- Add [directory templates](https://www.11ty.dev/docs/data-template-dir/) to enable `showDate` for podcasts, mixes, and productions