### PR TITLE
Refactor redirect rules to fix /cms/ redirect issue

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -103,5 +103,9 @@
 /cms/2008/11/04/empire-of-the-sun-walking-on-a-dream-funkfinders-discoid-remix/ /productions/empire-of-the-sun-walking-on-a-dream-funkfinders-discoid-remix/ 301
 
 # Change all other urls from old CMS route
+
+# This route has to before before the splat one
+# otherwise it matches the wildcard and we end up with // as the final path
+# Netlify seems to not like this
+/cms / 301
 /cms/* /:splat/ 301
-/cms /index.html 301


### PR DESCRIPTION
## Changes

- Fix `/cms/` redirect not working with Netlify