### PR TITLE
Add Apple podcast verification to XML feed

### DIFF
--- a/src/_data/podcast.js
+++ b/src/_data/podcast.js
@@ -35,5 +35,6 @@ module.exports = {
     }
     // spotify: 'TODO',
     // google: 'TODO',
-  ]
+  ],
+  applePodcastVerifyToken: '16282ae0-85a3-11f0-8acf-79214989a92e'
 };

--- a/src/pages/xmlFeeds/podcast.liquid
+++ b/src/pages/xmlFeeds/podcast.liquid
@@ -24,6 +24,9 @@ sitemap:
     </itunes:owner>
     <itunes:category text="{{podcast.category}}" />
     <itunes:new-feed-url>{{site.url}}{{podcast.feedPath}}</itunes:new-feed-url>
+    {%- if podcast.applePodcastVerifyToken -%}
+    <itunes:applepodcastsverify>{{ podcast.applePodcastVerifyToken }}</itunes:applepodcastsverify>
+    {%- endif -%}
     
     {%- for podcastEpisode in collections.podcast reversed -%}
       <item>


### PR DESCRIPTION
## Changes

- Claim the [DJ Cruze Apple podcast feed](https://podcasts.apple.com/us/podcast/dj-cruze-house-music-podcast/id89935810)

I should have done this years ago but I created the podcast back in 2005 before these tools were available!