### PR TITLE
fix: proxy media files through djcruze.co.uk to fix mobile downloads

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  publish = "_site"
+  command = "npm run build"
+
+# Proxy media files through djcruze.co.uk to enable the HTML download attribute.
+# The download attribute only works for same-origin files — without this proxy,
+# Chrome on Android (and other browsers) ignore it and play the file instead.
+[[redirects]]
+  from = "/media/*"
+  to = "https://f001.backblazeb2.com/file/djcruzemedia/:splat"
+  status = 200
+  force = true

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -19,5 +19,9 @@ module.exports = {
   twitterUsername: 'djcruze',
   author: 'https://www.facebook.com/housedjcruze',
   facebookAppId: '',
-  mediaFilesUrl: 'https://f001.backblazeb2.com/file/djcruzemedia'
+  // Use a same-origin proxy path in production so the HTML download attribute
+  // works correctly on mobile browsers (e.g. Chrome on Android).
+  // Netlify rewrites /media/* → https://f001.backblazeb2.com/file/djcruzemedia/*
+  // See netlify.toml for the redirect rule.
+  mediaFilesUrl: isDevelopmentBuild ? 'https://f001.backblazeb2.com/file/djcruzemedia' : '/media'
 }


### PR DESCRIPTION
## Problem

The HTML `download` attribute is ignored by browsers for cross-origin files. Audio files are hosted on Backblaze B2 (`f001.backblazeb2.com`) — a different domain to `djcruze.co.uk`. This caused Chrome on Android (and other mobile browsers) to open the file in the browser and play it instead of downloading it.

## Fix

Two small changes:

1. **`netlify.toml`** (new file) — adds a Netlify proxy redirect so `/media/*` transparently rewrites to `https://f001.backblazeb2.com/file/djcruzemedia/*` with status 200. Netlify fetches the file server-side and serves it from the same origin.

2. **`src/_data/site.js`** — `mediaFilesUrl` now uses `/media` in production (same-origin), while keeping the direct Backblaze URL for local dev so development still works without Netlify.

No changes to templates or content files needed — `{{site.mediaFilesUrl}}` is already used consistently throughout.

## Result

All audio download links become same-origin requests, so the `download` attribute is respected and the file downloads correctly on Chrome for Android and all other browsers.